### PR TITLE
Remove LaTeX dependency for faster Travis CI/CD builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python - "3.6"
 
-before_install:
-  # - sudo apt-get -qq update
-  - travis_wait 30 sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended
-
 install:
   - pip install --user sphinx sphinx-rtd-theme travis-sphinx
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,7 @@ release = ''
 # ones.
 extensions = [
     'sphinx.ext.todo',
-    'sphinx.ext.imgmath',
+    'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
 ]


### PR DESCRIPTION
Using MathJax (via the Cloudflare CDN) instead of installing ~1GB of LaTeX .debs locally should result in much faster Travis runs.